### PR TITLE
Avoid opening temporary files twice

### DIFF
--- a/src/pvgmsh/__init__.py
+++ b/src/pvgmsh/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import tempfile
+from pathlib import Path
 
 import gmsh
 import numpy as np
@@ -95,10 +96,13 @@ def frontal_delaunay_2d(
         encoding="utf-8",
         newline="\n",
         suffix=".msh",
+        delete=False,
     ) as fp:
         gmsh.write(fp.name)
-        mesh = pv.read(fp.name)
-        mesh.clear_data()
+
+    mesh = pv.read(fp.name)
+    mesh.clear_data()
+    Path(fp.name).unlink()
 
     gmsh.clear()
     gmsh.finalize()


### PR DESCRIPTION
Avoid opening temporary files twice.

https://docs.python.org/3.12/library/tempfile.html#tempfile.NamedTemporaryFile
> Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows).